### PR TITLE
feat: add support for finding a key of a given item

### DIFF
--- a/src/AbstractStorage.php
+++ b/src/AbstractStorage.php
@@ -54,6 +54,34 @@ abstract class AbstractStorage
     public abstract function load(): void;
 
     /**
+     * Returns the key of an item.
+     */
+    public function findKey(Item $item): ItemKey|KeyNotFound
+    {
+        $itemValue = $item->bind();
+        foreach ($this->map as $key => $storedItem) {
+            $storedItemValue = $storedItem->bind();
+            if (is_object($storedItemValue) === true) {
+                if (method_exists($storedItemValue, "equals") === false) {
+                    foreach ($storedItemValue as $propName => $propValue) {
+                        if ($itemValue->$propName !== $propValue) {
+                            break 2;
+                        }
+                    }
+                    return $key;
+                }
+                if ($storedItemValue->equals($itemValue) === true) {
+                    return $key;
+                }
+            }
+            if ($storedItemValue === $itemValue) {
+                return $key;
+            }
+        }
+        return new KeyNotFound();
+    }
+
+    /**
      * Returns the number of all stored items.
      */
     public function getCount(): int

--- a/src/KeyNotFound.php
+++ b/src/KeyNotFound.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpolar\Phpolar\Storage;
+
+/**
+ * Represents the scenario when the key of an item is not found.
+ */
+final class KeyNotFound
+{
+}


### PR DESCRIPTION
There should be a method of keeping track of stored items.  Alternatively, users can store unique keys with the data.