### PR TITLE
ci: use node 16 compatible github actions

### DIFF
--- a/.github/workflows/php-latest.yml
+++ b/.github/workflows/php-latest.yml
@@ -13,7 +13,7 @@ jobs:
         php-versions: [latest, nightly]
         phpunit-versions: ['latest']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -25,7 +25,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
Node 12 was deprecated.